### PR TITLE
feat: Sonarr Import List mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ docker-compose.yaml
 
 # Cache directories
 config/log/*
+config/list/*
 code/__pycache__/*
 
 # Known configs

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM python:3
 WORKDIR /code
 COPY code /code/
 RUN pip install -r requirements.txt
+RUN apt-get update && apt-get install -y nginx
+EXPOSE 8080
 CMD ["/code/runSync.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3
 WORKDIR /code
 COPY code /code/
-RUN pip install -r requirements.txt
-RUN apt-get update && apt-get install -y nginx
+RUN pip install --no-cache-dir -r requirements.txt
+RUN apt-get update && apt-get install -y --no-install-recommends nginx \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 EXPOSE 8080
 CMD ["/code/runSync.sh"]

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ It is highly recommended to use [RickDB/PlexMALSync](https://github.com/RickDB/P
 ## Running in Docker (Recommended)
 You can use the included docker-compose file to run the script in a docker container.
 See [Env](#env) for more variables.
-```
-version: '3.7'
+```docker
+version: '3.8'
 services:
   aniplanrr:
     container_name: aniplanrr
@@ -65,6 +65,7 @@ INTERVAL=3600                               # Interval in seconds to run the scr
 LOGGING=False                               # If True, will add extra output for debug purposes! Also generates a logging folder (config/log)
 RESPECTFUL_ADDING                           # If True, will not even touch a series if it's already listed in the application
 AUTO_FILL_MAPPING                           # Allow the program to write mapping entries - See mapping down under config files
+SONARRIMPORTER=True                         # If true, hosting on port 8080 on /sonarr will display an import list
 ```
 
 ## Config Files

--- a/code/aniplanrr.py
+++ b/code/aniplanrr.py
@@ -31,8 +31,19 @@ def runSonarr(sonarr, aniList):
     if LOGGING == "True":
         pr("Found " + str(len(newShowList)) + " new shows to add to Sonarr")
     
-    # send each item in newShows to get_id_from_sonarr
-    sendToSonarr(sonarr, newShowList, sonarrList)
+    if SONARRIMPORTER:
+        genIndex()
+        finalForm = updateSonarrImport(sonarr, newShowList, sonarrList)
+        content = json.dumps(finalForm, sort_keys=True, indent=2)
+        with open(webPath + 'sonarr', 'w') as f:
+            f.write(content)
+        pr("Wrote sonarr")
+        params = {'name': 'ImportListSync'}
+        requests.post(sonarr['APIURL'] + '/command/?' + sonarr['APIKEY'], json=params)
+        pr("Sent command to Sonarr to import new shows")
+    else:
+        # send each item in newShows to get_id_from_sonarr
+        sendToSonarr(sonarr, newShowList, sonarrList)
 
 def runRadarr(radarr, aniMovieList):
     if LOGGING == "True":

--- a/code/aniplanrr.py
+++ b/code/aniplanrr.py
@@ -23,10 +23,11 @@ def runSonarr(sonarr, aniList):
         pr("Sonarr List is empty")
         #stop execution
         return False
+
     # Remove obvious matches
     newShowList = diffDicts(aniList, sonarrList)
+
     # Remove less obvious matches via IDs/Mapping
-    
     newShowList = indexSonarrList(sonarr, newShowList, mapping, sonarrList)
     if LOGGING == "True":
         pr("Found " + str(len(newShowList)) + " new shows to add to Sonarr")

--- a/code/aniplanrr.py
+++ b/code/aniplanrr.py
@@ -32,7 +32,6 @@ def runSonarr(sonarr, aniList):
         pr("Found " + str(len(newShowList)) + " new shows to add to Sonarr")
     
     if SONARRIMPORTER:
-        genIndex()
         finalForm = updateSonarrImport(sonarr, newShowList, sonarrList)
         content = json.dumps(finalForm, sort_keys=True, indent=2)
         with open(webPath + 'sonarr', 'w') as f:
@@ -59,6 +58,8 @@ def runRadarr(radarr, aniMovieList):
     sendToRadarr(radarr, newMoviesList, radarrList)
 
 def main():
+    if SONARRIMPORTER:
+        genIndex()
     if LOGGING == "True":
         pr("Getting AniList for " + ANILIST_USERNAME)
     [aniList, aniMovieList] = getAniList(str(ANILIST_USERNAME))

--- a/code/nginx.conf
+++ b/code/nginx.conf
@@ -1,0 +1,14 @@
+events {}
+http {
+  index index.html;
+
+  server {
+    listen 8080 default_server;
+    server_name _; # This is just an invalid value which will never trigger on a real hostname.
+    # access_log logs/default.access.log main;
+
+    server_name_in_redirect off;
+
+    root  /config/list;
+  }
+}

--- a/code/radarr.py
+++ b/code/radarr.py
@@ -30,7 +30,7 @@ def setupRadarr(RADARRURL, RADARRAPIKEY):
             dumpVar('failedradarrResponse', response.json())
         return False
     answer = response.json()
-    if answer['appName'] == 'Radarr' or answer['instaneName'] == 'Radarr':
+    if answer['appName'] == 'Radarr' or answer['instanceName'] == 'Radarr':
         if LOGGING == "True":
             pr("Confirmed Radarr instance URL and Key, returning information!")
     else:
@@ -70,7 +70,7 @@ def addMovie(radarr, movie):
         # write params to file
         dumpVar('addMovieParams', movie)
     response = requests.post(radarr['APIURL'] + '/movie?' + radarr['APIKEY'], json=stripExtraKeys(movie))
-    # If resposne is 201, print success
+    # If response is 201, print success
     if response.status_code == 201:
         pr(movie['title'] + " was added to Radarr")
         if AUTO_FILL_MAPPING is True:
@@ -102,7 +102,7 @@ def getRadarrTagId(radarr, tag_name):
     }
     response = requests.get(radarr['APIURL'] + '/tag?' + radarr['APIKEY'])
     tag_id = None
-    # get id of tag labeled "fronAniList"
+    # get id of tag labeled "fromAniList"
     # find id in response.json() where label = tag_name
     for i in response.json():
         if i['label'] == tag_name.lower():

--- a/code/runSync.sh
+++ b/code/runSync.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+nginx -c /code/nginx.conf
 while true
 do
   echo "Running aniplanrr.py"

--- a/code/sonarr.py
+++ b/code/sonarr.py
@@ -253,3 +253,17 @@ def sendToSonarr(sonarr, listToAdd, sonarrList):
     # send each item in listToAdd to add_show_to_sonarr
     for show in listToAdd:
         addShow(sonarr, show)
+
+def updateSonarrImport(sonarr, listToAdd, sonarrList):
+    # Create a form that will be used to fill the hosted list
+    finalForm = []
+    entry = {
+        'tvdbId': '0'
+    }
+    for show in listToAdd:
+        if show['tvdbId']:
+            entry['tvdbId'] = str(show['tvdbId'])
+            finalForm.append(entry)
+        else:
+            pr("Error: This show has no tvdbId?! " + show['title'])
+    return finalForm

--- a/code/sonarr.py
+++ b/code/sonarr.py
@@ -257,10 +257,10 @@ def sendToSonarr(sonarr, listToAdd, sonarrList):
 def updateSonarrImport(sonarr, listToAdd, sonarrList):
     # Create a form that will be used to fill the hosted list
     finalForm = []
-    entry = {
-        'tvdbId': '0'
-    }
     for show in listToAdd:
+        entry = {
+            'tvdbId': '0'
+        }
         if show['tvdbId']:
             entry['tvdbId'] = str(show['tvdbId'])
             finalForm.append(entry)

--- a/code/sonarr.py
+++ b/code/sonarr.py
@@ -31,7 +31,7 @@ def setupSonarr(SONARRURL, SONARRAPIKEY):
             dumpVar('failedSonarrResponse', response.json())
         return False
     answer = response.json()
-    if answer['appName'] == 'Sonarr' or answer['instaneName'] == 'Sonarr':
+    if answer['appName'] == 'Sonarr' or answer['instanceName'] == 'Sonarr':
         if LOGGING == "True":
             pr("Confirmed Sonarr instance URL and Key, returning information!")
     else:
@@ -102,7 +102,7 @@ def addShow(sonarr, show):
         dumpVar('addShowShow', show)
     response = requests.post(
         sonarr['APIURL'] + '/series?' + sonarr['APIKEY'], json=stripExtraKeys(show))
-    # If resposne is 201, print success
+    # If response is 201, print success
     if response.status_code == 201:
         pr(show['title'] + " was added to Sonarr")
         if LOGGING == "True":
@@ -146,7 +146,7 @@ def getSonarrTagId(sonarr, tag_name):
         'label': tag_name
     }
     response = requests.get(sonarr['APIURL'] + '/tag?' + sonarr['APIKEY'])
-    # get id of tag labeled "fronAniList"
+    # get id of tag labeled "fromAniList"
     tag_id = None
     for i in response.json():
         if i['label'] == tag_name.lower():
@@ -169,7 +169,7 @@ def updateSonarrSeason(sonarr, show):
                           "searchForMissingEpisodes": 'true'}
     response = requests.put(
         sonarr['APIURL'] + '/series/' + str(show['id']) + '?' + sonarr['APIKEY'], json=stripExtraKeys(show))
-    # If resposne is 201, print success
+    # If response is 201, print success
     if response.status_code == 202:
         pr(show['title'] + " season " +
            str(show['season']) + " was added to Sonarr")

--- a/code/util.py
+++ b/code/util.py
@@ -187,7 +187,7 @@ def addMapping(item):
 def animeMatch(result, show):
     matching = 0
     # Check romanji and english title VS all titles in results
-    #if result['title'] contains year in paranthesis, remove the year
+    #if result['title'] contains year in parenthesis, remove the year
     if re.search(r'\(\d{4}\)', result['title']):
         result['title'] = re.sub(r'\(\d{4}\)', '', result['title']).rstrip()
     for title in show['titles'].values():

--- a/code/util.py
+++ b/code/util.py
@@ -21,6 +21,7 @@ MONITOR = os.getenv('MONITOR')
 RETRY = os.getenv('RETRY')
 if RETRY is not None:
     RETRY = RETRY.capitalize()
+SONARRIMPORTER = os.getenv('SONARRIMPORTER')
 RESPECTFUL_ADDING = os.getenv('RESPECTFUL_ADDING')
 AUTO_FILL_MAPPING = os.getenv('AUTO_FILL_MAPPING')
 LOGGING = os.getenv('LOGGING')
@@ -48,6 +49,7 @@ if RADARRURL is not None:
         RADARRANIMEPATH = RADARRANIMEPATH.replace('"', '')
 
 logPath = configPath + 'log/'
+webPath = configPath + 'list/'
 mappingFile = configPath + 'mapping.csv'
 
 
@@ -258,3 +260,22 @@ def diffDicts(dict1, dict2):
         if not any(compareDicts(i, j) for j in dict2):
             diff.append(i)
     return diff
+
+def genIndex():
+    if not os.path.exists(webPath):
+        os.makedirs(webPath)
+    content = """
+    <html>
+        <head>
+            <title>AniPlanrr</title>
+        </head>
+        <body>
+            <h1>AniPlanrr</h1>
+            <p>There are sub-sites, based on your config option, at /sonarr and /radarr which host the import lists.</p>
+            <p>Also, don't expose this to the internet!</p>
+        </body>
+    </html>
+    """
+    with open(webPath + 'index.html', 'w') as f:
+        f.write(content)
+    return True

--- a/docker-compose.yaml.example
+++ b/docker-compose.yaml.example
@@ -3,12 +3,23 @@ services:
   aniplanrr:
     container_name: aniplanrr
     image: ghcr.io/noggl/aniplanrr:main
+    ## Example for building from source
+    # container_name: aniplanrr
+    # image: aniplanrr
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    ## Settings for SONARRIMPORTER
+    # network_mode: host
+    # ports:
+    #   - 8080:8080
     restart: unless-stopped
     environment:
-      - SONARRURL=http://sonarr_url_and_port/api/   # Sonarr URL (ex: http://localhost:8989/api/)
+      - SONARRURL=http://sonarr_url_and_port/       # Sonarr URL (ex: http://localhost:8989/)
       - SONARRAPIKEY=your_api_key                   # Sonarr API Key
       - SONARRANIMEPATH=/path/to/anime              # Sonarr Anime Path (ex: /tv/anime/)
-      - RADARRURL=http://radarr_url_and_port/api/   # Radarr URL (ex: http://localhost:7878/api/)
+      - SONARRIMPORTER=True                         # If True, will host the Import list on port 8080
+      - RADARRURL=http://radarr_url_and_port/       # Radarr URL (ex: http://localhost:7878/)
       - RADARRAPIKEY=your_api_key                   # Radarr API Key
       - RADARRANIMEPATH=/path/to/anime              # Radarr Anime Path (ex: /movies/anime/)
       - ANILIST_USERNAME=yourname                   # AniList Username

--- a/docker-compose.yaml.example
+++ b/docker-compose.yaml.example
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.8'
 services:
   aniplanrr:
     container_name: aniplanrr


### PR DESCRIPTION
# Import List Mode
The long awaited Import List Mode has arrived!
Sleep is for the week. Which week? Next one, obviously.

- [X] Import List Mode fully working in Sonarr
- [X] Full nginx server because writing webhosting code is hard and unnecessary

When combined with RESPECTFUL_ADDING, this should, and mostly does minus some unidentified bugs, create a list of all anime we want to add, and then remove the entries that are already added on every refresh.

![image](https://github.com/noggl/AniPlanrr/assets/1676068/6db83fdb-ce50-44e9-a5eb-970da06c01ca)

Note: Your URL may vary, that is my legitimate URL though in my use case.

I know what you're thinking. "But Rojikku, I want to import on every refresh, not every six hours!"
Fortunately, do I have just the thing for you, my impatient friends. It uses the API to force a refresh on every load! Therefore, auto-matching the interval from AniPlanrr. Additionally, you can set all sorts of nice settings straight in the import list settings, and not have to mess with them in code at all!

Radarr uses a different format so I'm neglecting it for the time being. It's not necessarily harder, it's just late at night and I'm the big sleepy.

P.S. You may have noticed I used a json= in my post request. If I did not do this, the API call did not work. I might recommend investigating any other calls you use that don't do this.